### PR TITLE
[iOS][WWFT-10886] - Modify TSMessage to take in an optional button

### DIFF
--- a/Pod/Classes/TSMessage.h
+++ b/Pod/Classes/TSMessage.h
@@ -129,7 +129,7 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
                                 subtitle:(NSString *)subtitle
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
-                     canBeDismissedByUser:(BOOL)dismissingEnabled;
+                    canBeDismissedByUser:(BOOL)dismissingEnabled;
 
 
 
@@ -141,6 +141,7 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
  @param type The notification type (Message, Warning, Error, Success)
  @param duration The duration of the notification being displayed
  @param callback The block that should be executed, when the user tapped on the message
+ @param button a custom button that can provide additional functionality (optional)
  @param buttonTitle The title for button (optional)
  @param buttonCallback The block that should be executed, when the user tapped on the button
  @param messagePosition The position of the message on the screen
@@ -153,6 +154,7 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
                                 callback:(void (^)())callback
+                                  button:(UIButton *)button
                              buttonTitle:(NSString *)buttonTitle
                           buttonCallback:(void (^)())buttonCallback
                               atPosition:(TSMessageNotificationPosition)messagePosition

--- a/Pod/Classes/TSMessage.m
+++ b/Pod/Classes/TSMessage.m
@@ -75,10 +75,11 @@ __weak static UIViewController *_defaultViewController;
                                       type:type
                                   duration:duration
                                   callback:nil
+                                    button:nil
                                buttonTitle:nil
                             buttonCallback:nil
                                 atPosition:TSMessageNotificationPositionTop
-                       canBeDismissedByUser:YES];
+                      canBeDismissedByUser:YES];
 }
 
 + (void)showNotificationInViewController:(UIViewController *)viewController
@@ -86,7 +87,7 @@ __weak static UIViewController *_defaultViewController;
                                 subtitle:(NSString *)subtitle
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
-                     canBeDismissedByUser:(BOOL)dismissingEnabled
+                    canBeDismissedByUser:(BOOL)dismissingEnabled
 {
     [self showNotificationInViewController:viewController
                                      title:title
@@ -95,10 +96,11 @@ __weak static UIViewController *_defaultViewController;
                                       type:type
                                   duration:duration
                                   callback:nil
+                                    button:nil
                                buttonTitle:nil
                             buttonCallback:nil
                                 atPosition:TSMessageNotificationPositionTop
-                       canBeDismissedByUser:dismissingEnabled];
+                      canBeDismissedByUser:dismissingEnabled];
 }
 
 + (void)showNotificationInViewController:(UIViewController *)viewController
@@ -113,6 +115,7 @@ __weak static UIViewController *_defaultViewController;
                                       type:type
                                   duration:TSMessageNotificationDurationAutomatic
                                   callback:nil
+                                    button:nil
                                buttonTitle:nil
                             buttonCallback:nil
                                 atPosition:TSMessageNotificationPositionTop
@@ -127,6 +130,7 @@ __weak static UIViewController *_defaultViewController;
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
                                 callback:(void (^)())callback
+                                  button:(UIButton *)button
                              buttonTitle:(NSString *)buttonTitle
                           buttonCallback:(void (^)())buttonCallback
                               atPosition:(TSMessageNotificationPosition)messagePosition
@@ -140,6 +144,7 @@ __weak static UIViewController *_defaultViewController;
                                                    duration:duration
                                            inViewController:viewController
                                                    callback:callback
+                                                     button:button
                                                 buttonTitle:buttonTitle
                                              buttonCallback:buttonCallback
                                                  atPosition:messagePosition

--- a/Pod/Classes/TSMessageView.h
+++ b/Pod/Classes/TSMessageView.h
@@ -42,6 +42,7 @@
  @param duration The duration this notification should be displayed (optional)
  @param viewController The view controller this message should be displayed in
  @param callback The block that should be executed, when the user tapped on the message
+ @param button a custom button that can provide additional functionality (optional)
  @param buttonTitle The title for button (optional)
  @param buttonCallback The block that should be executed, when the user tapped on the button
  @param position The position of the message on the screen
@@ -54,6 +55,7 @@
            duration:(CGFloat)duration
    inViewController:(UIViewController *)viewController
            callback:(void (^)())callback
+             button:(UIButton *)button
         buttonTitle:(NSString *)buttonTitle
      buttonCallback:(void (^)())buttonCallback
          atPosition:(TSMessageNotificationPosition)position

--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -108,6 +108,7 @@ static NSMutableDictionary *_notificationDesign;
            duration:(CGFloat)duration
    inViewController:(UIViewController *)viewController
            callback:(void (^)())callback
+             button:(UIButton *)button
         buttonTitle:(NSString *)buttonTitle
      buttonCallback:(void (^)())buttonCallback
          atPosition:(TSMessageNotificationPosition)position
@@ -191,9 +192,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             [self addSubview:self.backgroundBlurView];
         }
         
-        UIColor *fontColor = [UIColor colorFromHexString:[current valueForKey:@"textColor"]
-                                                  ];
-        
+        UIColor *fontColor = [UIColor colorFromHexString:[current valueForKey:@"textColor"]];
         
         self.textSpaceLeft = xPadding;
         if (image) self.textSpaceLeft += image.size.width + xPadding;
@@ -261,8 +260,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         }
         
         // Set up button (if set)
-        _button = [UIButton buttonWithType:UIButtonTypeCustom];
-        
+        _button = (button) ? button : [UIButton buttonWithType:UIButtonTypeCustom];
         
         UIImage *buttonBackgroundImage = [UIImage imageNamed:[current valueForKey:@"buttonBackgroundImageName"]];
         
@@ -325,8 +323,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
                                                                    0.0, // will be set later
                                                                    screenWidth,
                                                                    [[current valueForKey:@"borderHeight"] floatValue])];
-            self.borderView.backgroundColor = [UIColor colorFromHexString:[current valueForKey:@"borderColor"]
-                                                                   ];
+            self.borderView.backgroundColor = [UIColor colorFromHexString:[current valueForKey:@"borderColor"]];
             self.borderView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
             [self addSubview:self.borderView];
         }


### PR DESCRIPTION
# Issue

Currently the hit area for the close button of an inline notification is very small, making them very difficult to dismiss. This is due to the fact that TSMessageView automatically sets the size of a button to be the size of our passed in 'X' image, which is very small. 
# Solution

The simplest solution is to modify TSMessageView to use W2ExpandableButton, which allows us to expand the button's hit area. However, since we don't want TSMessages to have any knowledge of Words related code, a better solution is to modify TSMessage methods to take in an optional button parameter, allowing us to pass in a W2ExpandableButton that we initialize elsewhere.

There will be an associated PR in Words to initialize this custom button and make the modified method call.
# Tests

Will be covered in associated PR in Words
# JIRA

https://jira.corp.zynga.com/browse/WWFT-10886
