### PR TITLE
[WWFT-11642] - Design tweaks for inline notifications

### DIFF
--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -414,9 +414,9 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
     if (self.iconImageView)
     {
         // Check if that makes the popup larger (height)
-        if (self.iconImageView.frame.origin.y + self.iconImageView.frame.size.height + yPadding > currentHeight)
+        if (self.iconImageView.frame.size.height + 2*yPadding > currentHeight)
         {
-            currentHeight = self.iconImageView.frame.origin.y + self.iconImageView.frame.size.height + yPadding;
+            currentHeight = self.iconImageView.frame.size.height + 2*yPadding;
         }
         else
         {
@@ -439,18 +439,59 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
     }
     
     currentHeight += self.borderView.frame.size.height;
+
+    
+    CGFloat yOffset = 0.0f;
+    if (self.messagePosition == TSMessageNotificationPositionNavBarOverlay)
+    {
+        // Increase height of frame to account for status bar (we subtract yPadding or top spacing appears disproportionately large)
+        CGSize statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
+        yOffset = MAX(0, MIN(statusBarSize.width, statusBarSize.height)-yPadding);
+        currentHeight += yOffset;
+    }
     
     self.frame = CGRectMake(0.0, self.frame.origin.y, self.frame.size.width, currentHeight);
     
-    
+    // Reposition UI elements
     if (self.button)
     {
         self.button.frame = CGRectMake(self.frame.size.width - self.textSpaceRight,
-                                       round((self.frame.size.height / 2.0) - self.button.frame.size.height / 2.0),
+                                       round(((self.frame.size.height-yOffset) / 2.0) - self.button.frame.size.height / 2.0) + yOffset,
                                        self.button.frame.size.width,
                                        self.button.frame.size.height);
     }
     
+    if (self.titleLabel)
+    {
+        self.titleLabel.frame = CGRectMake(self.titleLabel.frame.origin.x,
+                                           self.titleLabel.frame.origin.y + yOffset,
+                                           self.titleLabel.frame.size.width,
+                                           self.titleLabel.frame.size.height);
+    }
+    
+    if (self.contentLabel)
+    {
+        self.contentLabel.frame = CGRectMake(self.contentLabel.frame.origin.x,
+                                             self.titleLabel.frame.origin.y + self.titleLabel.frame.size.height,
+                                             self.contentLabel.frame.size.width,
+                                             self.contentLabel.frame.size.height);
+    }
+    
+    if (self.iconImageView)
+    {
+        self.iconImageView.frame = CGRectMake(self.iconImageView.frame.origin.x,
+                                              round(((self.frame.size.height-yOffset) / 2.0) - self.iconImageView.frame.size.height / 2.0) + yOffset,
+                                              self.iconImageView.frame.size.width,
+                                              self.iconImageView.frame.size.height);
+    }
+    
+    if (self.borderView)
+    {
+        self.borderView.frame = CGRectMake(self.borderView.frame.origin.x,
+                                           self.borderView.frame.origin.y + yOffset,
+                                           self.borderView.frame.size.width,
+                                           self.borderView.frame.size.height);
+    }
     
     CGRect backgroundFrame = CGRectMake(self.backgroundImageView.frame.origin.x,
                                         self.backgroundImageView.frame.origin.y,

--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -444,9 +444,9 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
     CGFloat yOffset = 0.0f;
     if (self.messagePosition == TSMessageNotificationPositionNavBarOverlay)
     {
-        // Increase height of frame to account for status bar (we subtract yPadding or top spacing appears disproportionately large)
+        // Increase height of frame to account for status bar (we subtract a small amount or top spacing appears disproportionately large)
         CGSize statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
-        yOffset = MAX(0, MIN(statusBarSize.width, statusBarSize.height)-yPadding);
+        yOffset = MAX(0, MIN(statusBarSize.width, statusBarSize.height)-7.0f);
         currentHeight += yOffset;
     }
     

--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -352,9 +352,9 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         {
             UISwipeGestureRecognizer *gestureRec = [[UISwipeGestureRecognizer alloc] initWithTarget:self
                                                                                              action:@selector(fadeMeOut)];
-            [gestureRec setDirection:(self.messagePosition == TSMessageNotificationPositionTop ?
-                                      UISwipeGestureRecognizerDirectionUp :
-                                      UISwipeGestureRecognizerDirectionDown)];
+            [gestureRec setDirection:(self.messagePosition == TSMessageNotificationPositionBottom ?
+                                      UISwipeGestureRecognizerDirectionDown :
+                                      UISwipeGestureRecognizerDirectionUp)];
             [self addGestureRecognizer:gestureRec];
             
             UITapGestureRecognizer *tapRec = [[UITapGestureRecognizer alloc] initWithTarget:self


### PR DESCRIPTION
# Issue

Currently the inline notifications we show are not entirely in line (ha) with our expectations. We use different message positions for different situations, leading to inconsistent vertical spacings, none of which are quite what we are looking for. The behavior we we want is for inline notifications to add extra padding to account for the status bar if shown, and for UI elements to appear centered vertically between the status bar and the bottom of the notification.
# Solution

All inline notifications now appear at the position TSMessageNotificationPositionNavBarOverlay. I've tweaked the behavior for this position to increase the height of the background frame by the height of the status bar if shown. All UI elements are also shifted down to be centered vertically between the status bar and the bottom of the notification.

On a somewhat unrelated note, I've also changed the dismissal gesture recognizer swipe direction for TSMessageNotificationPositionNavBarOverlay to be swipe up rather than swipe down, since the inline notification appears at the top of the screen.
# Tests
- [x] Schedule local notifications on iPhone simulator, verify that inline notifications account for status bar
- [x] Schedule local notifications on iPad simulator, verify that inline notifications do not add spacing with no status bar present
# JIRA

https://jira.corp.zynga.com/browse/WWFT-11642
